### PR TITLE
fix building placement bug

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -196,7 +196,7 @@ Game.prototype.build = function(xOnBoard,yOnBoard) {
     this.board.placeBuilding(building);
     this.buildings.push(building);
     this.currentBuildOrder = building;
-    // building = undefined; // do this work in the game model and change the view somehow, too
+    this.selectedBuilding = undefined;
   }
 }
 


### PR DESCRIPTION
I originally turned off the need to select a building every time you wanted to build one. This meant that a building was only being instantiated once per building button click. So when trying to place something on the board, it would point to the same object in memory as the last one placed.

To patch this in the short term, I have uncommented the line that resets the game.selectedBuilding. This forces users to select a building (and hence instantiate it) every time they want to build.
