### PR TITLE
Fix NaN stats error

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -227,7 +227,7 @@ Game.prototype.wereUnitsDestroyed = function(units) {
 
 Game.prototype.statsForDestroyed = function(units) {
   var totalDamageDealt = units.reduce(function(previousValue, unit/*, index, array */) {
-    return previousValue + units.maxHp;
+    return previousValue + unit.maxHp;
   }, 0);
   return {
     totalDamageDealt: totalDamageDealt,

--- a/js/game.js
+++ b/js/game.js
@@ -85,8 +85,8 @@ Game.prototype.runDrawCycle = function() {
   this.moveEnemies();
   this.board.refreshEnemies(this.enemies);
   this.board.drawAllHp(this.buildings);
-  this.board.buildingsNeedUpdate = this.wereUnitsDestroyed(this.buildings);
-  this.board.enemiesNeedUpdate = this.wereUnitsDestroyed(this.enemies);
+  this.board.buildingsNeedUpdate = this.wereUnitsDestroyed(this.buildings, this.destroyedBuildings);
+  this.board.enemiesNeedUpdate = this.wereUnitsDestroyed(this.enemies, this.destroyedEnemies);
   if (this.board.buildingsNeedUpdate) {
     this.board.buildingRefresh(this.buildings);
   }
@@ -214,11 +214,11 @@ Game.prototype.deductEnergy = function(deduction) {
   this.resources.energy -= deduction;
 };
 
-Game.prototype.wereUnitsDestroyed = function(units) {
+Game.prototype.wereUnitsDestroyed = function(units, unitGraveyard) {
   var isAtLeastOneDestroyed = false;
   for (var i = 0; i < units.length; i++) {
     if (units[i].isDestroyed()) {
-      this.destroyedEnemies.push(units.splice(i, 1)[0]);
+      unitGraveyard.push(units.splice(i, 1)[0]);
       isAtLeastOneDestroyed = true;
     }
   }

--- a/js/game.js
+++ b/js/game.js
@@ -226,7 +226,7 @@ Game.prototype.wereUnitsDestroyed = function(units) {
 };
 
 Game.prototype.statsForDestroyed = function(units) {
-  var totalDamageDealt = units.reduce(function(previousValue, unit/*, index, array */) {
+  var totalDamageDealt = units.reduce(function(previousValue, unit) {
     return previousValue + unit.maxHp;
   }, 0);
   return {


### PR DESCRIPTION
`gameOverMessage` was showing NaN for enemy damage dealt and confusing `enemyStats` with `buildingStats`. In order to fix it:
- Removed typo in the reduce method (`units` to `unit`)
- Fix refactored `wereUnitsDestroyed()` method to take a `unitGraveyard` argument
